### PR TITLE
改进图表标题的配置

### DIFF
--- a/whu-thesis.cls
+++ b/whu-thesis.cls
@@ -373,10 +373,18 @@
 % 图表标题设置
 \RequirePackage [ labelsep = quad ] { caption } % 序号之后空一格写标题
 % 设置表格标题字体为黑体, 设置图标题字体为宋体
-\DeclareCaptionFont { tablecap } { \bfseries \tablecap }
-\captionsetup [ table ] { textfont = tablecap }
-\tl_set:Nn \figurename {                     \zihao { -4 } 图 }
-\tl_set:Nn \tablename  { \bfseries \tablecap \zihao { -4 } 表 }
+\DeclareCaptionFont { whutablecap  } { \heiti \addCJKfontfeatures { BoldFont = * } \bfseries \zihao { -4 } }
+\DeclareCaptionFont { whufigurecap } { \songti \zihao { -4 } }
+\captionsetup [ table ]
+  {
+    name = 表,
+    font = whutablecap
+  }
+\captionsetup [ figure ]
+  {
+    name = 图,
+    font = whufigurecap
+  }
 
 \RequirePackage { graphicx }
 \AtEndPreamble
@@ -517,7 +525,6 @@
   {
     \setCJKsansfont {#1} [#2]
     \newCJKfontfamily { \heiti } {#1} [#2]
-    \newCJKfontfamily { \tablecap } {#1} [ BoldFont = #1 ]
   }
 \cs_new_protected:Npn \__whu_set_cjk_font_fang:nn #1#2
   {


### PR DESCRIPTION
补充 7f81a764388，解决 #72。

* 去掉 `\tablecap`
* 完全使用 caption 宏包配置图表标题

猛然发现可以在 `\addCJKfontfeature` 中用 `*` 引用字体名。

7f81a764388 使得在正文里使用 `\autoref` 引用表格时也会带上黑体格式设置，我查了下好像 `\xxxname` 约定俗成应该只用纯文本，干脆全用 `\captionsetup` 设置了。

生成的 PDF 就不提交了，这种应该放在 Release 里吧？