### PR TITLE
Update whu-thesis-doc.tex: Typo fixed

### DIFF
--- a/whu-thesis-doc.tex
+++ b/whu-thesis-doc.tex
@@ -229,9 +229,9 @@
     《通用十进制分类法》（UDC）分类号。
 \end{function}
 
-\begin{function}{info/secrete-level}
-    \begin{fdusyntax}[emph={[1]secrete-level}]
-        secrete-level = (*\marg{密级}*)
+\begin{function}{info/secret-level}
+    \begin{fdusyntax}[emph={[1]secret-level}]
+        secret-level = (*\marg{密级}*)
     \end{fdusyntax}
     论文密级，公开型论文可不注明。
 \end{function}


### PR DESCRIPTION
Typo fixed.
There is typo in the [whu-thesis-doc.tex](https://github.com/whutug/whu-thesis/blob/master/whu-thesis-doc.tex): 'secrete' should be corrected to 'secret'.