### PR TITLE
Fix advisor name and title

### DIFF
--- a/whu-thesis-demo.tex
+++ b/whu-thesis-demo.tex
@@ -2,7 +2,7 @@
 %%
 %% Created by WHUTUG
 
-\documentclass[type=master,oneside]{whu-thesis}
+\documentclass[type=doctor,oneside]{whu-thesis}
 \whusetup
   {
     info               =
@@ -15,8 +15,8 @@
         author*        = {Your Name},
         subject        = {学科},
         major          = {专业名称},
-        % advisor-name   = {教师姓名},
-        advisor        = {张三, 教授},
+        advisor-name   = {教师姓名},
+        advisor-title  = {教授},
         direction      = {研究方向},
         % date           = {2021/5},
         keywords       = {关键词 1 , 关键词 2 , 关键词 3 , 关键词 4 , 一个非常非常，非常非常长——的关键词 5},

--- a/whu-thesis.cls
+++ b/whu-thesis.cls
@@ -47,7 +47,7 @@
       { doctor , master , bachelor , opening }
       { \tl_gset_eq:NN \g__whu_option_type_tl \l_keys_choice_tl },
     type .initial:n        = doctor,
-    % 学位，默认本科生
+    % 学位，默认博士生
 
     class .value_required:n = true,
     class .choices:nn       =
@@ -825,7 +825,7 @@
     direction      .tl_gset:N    = \g__whu_info_direction_tl,
     date           .tl_gset:N    = \g__whu_info_date_tl,
     advisor-name   .tl_gset:N    = \g__whu_info_advisor_name_tl,
-    advisor        .clist_gset:N = \g__whu_info_advisor_clist,
+    advisor-title   .tl_gset:N    = \g__whu_info_advisor_title_tl,
     keywords       .clist_gset:N = \g__whu_info_keywords_clist,
     keywords *     .clist_gset:N = \g__whu_info_keywords_en_clist,
 
@@ -833,6 +833,10 @@
     date           .initial:n    =
       { \int_use:N \c_sys_year_int / \int_use:N \c_sys_month_int }
   }
+
+% concantenate advisor-name and advisor-title into advisor
+\tl_set:Nn \l_tmpa_tl { \g__whu_info_advisor_name_tl, \g__whu_info_advisor_title_tl }
+\clist_set:NV \g__whu_info_advisor_clist \l_tmpa_tl
 
 \tl_new:N \g__whu_element_innovation_tl
 \tl_new:N \g__whu_element_abstract_tl


### PR DESCRIPTION
There was `advisor-name` and `advisor`(name and title) at the same time, where master and doctor use `advisor` and bachelor should use `advisor-name`. This commit replace `advisor` with `advisor-title`.