### PR TITLE
修复本科摘要中摘要文件名错误

### DIFF
--- a/whu-thesis.cls
+++ b/whu-thesis.cls
@@ -2030,7 +2030,7 @@
       \chapter{ \c__whu_name_abstract_en_tl }
       \zihao{-4}
       % \g__whu_abstract_en_content_tl
-      \file_if_exist:nT { pages/abstract.tex }
+      \file_if_exist:nT { pages/enabstract.tex }
         {
           \file_input:n { pages/enabstract.tex }
         }


### PR DESCRIPTION
外校学生，不清楚这里为什么没改

贵校本科生的毕业论文是要求一定要有英文摘要，所以一直没发现？