### PR TITLE
Prevent English authors' names from being capitalized (#298)

### DIFF
--- a/whu-thesis.cls
+++ b/whu-thesis.cls
@@ -2774,6 +2774,7 @@
     \cs_undefine:N \addbibresource
     \clist_new:N \l__whu_biblatex_options_clist
     \clist_put_right:Nn \l__whu_biblatex_options_clist { backend = biber }
+    \clist_put_right:Nn \l__whu_biblatex_options_clist { gbnamefmt = lowercase }
     \clist_put_right:Nx \l__whu_biblatex_options_clist % 参考文献样式
       {
         style =


### PR DESCRIPTION
Set the biblatex parameters to prevent English authors' names from being fully capitalized.