### PR TITLE
Show only the major when subject is empty

### DIFF
--- a/whu-thesis.cls
+++ b/whu-thesis.cls
@@ -1451,7 +1451,9 @@
         \tl_if_empty:NF \l__whu_info_supervisor_outer_tl
           { \l__whu_info_supervisor_outer_tl 
             \l__whu_info_supervisor_outer_academic_title_tl },
-        \l__whu_info_subject_tl、\l__whu_info_major_tl,
+        \tl_if_empty:NF \l__whu_info_subject_tl
+          { \l__whu_info_subject_tl、}
+          \l__whu_info_major_tl,
         \l__whu_info_research_area_tl
       }
     \noindent


### PR DESCRIPTION
当学科```subject```设置为空时，封面页```学科、专业名称```会显示```、{{major}}```，修改后当```subject```为空时，仅显示```major```